### PR TITLE
Get supported Ubuntu releases from Launchpad

### DIFF
--- a/.github/scripts/get-supported-releases.py
+++ b/.github/scripts/get-supported-releases.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python3
+
+import sys
+from launchpadlib.launchpad import Launchpad
+from datetime import date
+
+### This Python script prints currently supported Ubuntu versions
+### Note: it isn't 100 % accurate, especially on LTS releases
+launchpad = Launchpad.login_anonymously('get-supported-releases', 'production') # login
+currentYear = date.today().year
+for series in launchpad.projects['ubuntu'].series:
+	# Launchpad seems to support LTS releases after their EOL, so at least compare the years
+	if series.supported and currentYear - series.datereleased.year <= 5:
+		print(series.name)

--- a/.github/scripts/ppa.sh
+++ b/.github/scripts/ppa.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-#!/bin/bash
-
 sudo apt install -y devscripts dput debhelper
 
-CHANNELS=( bionic focal jammy ) # TODO: Use Launchpad API to get supported Ubuntu releases
+CHANNELS=( $(.github/scripts/get-supported-releases.py) )
 VERSION=`git describe --tags --abbrev=0`
 VERSION=${VERSION//v}
 CURRENT_DIR=`pwd`


### PR DESCRIPTION
Use a Python script to get supported Ubuntu releases instead of a hard-coded list.