### PR TITLE
Install launchpadlib before uploading to PPA

### DIFF
--- a/.github/scripts/ppa.sh
+++ b/.github/scripts/ppa.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sudo apt install -y devscripts dput debhelper
+sudo apt install -y devscripts dput debhelper python3-launchpadlib
 
 CHANNELS=( $(.github/scripts/get-supported-releases.py) )
 VERSION=`git describe --tags --abbrev=0`


### PR DESCRIPTION
launchpadlib, which is needed by the get-supported-releases.py script, might not be installed